### PR TITLE
Fix SQL error on content entity reward

### DIFF
--- a/inc/plugins/mint/data.php
+++ b/inc/plugins/mint/data.php
@@ -215,7 +215,7 @@ function addContentEntityReward(string $rewardSourceName, int $contentEntityId, 
                     user_id = " . (int)$userId . " AND
                     content_type = '" . $db->escape_string($rewardSource['contentType']) . "' AND
                     content_entity_id = " . (int)$contentEntityId . " AND
-                    termination_point_id = " . (int)$terminationPointId . "
+                    currency_termination_point_id = " . (int)$terminationPointId . "
                 ")
             );
 


### PR DESCRIPTION
Fixes the misnamed column causing the following SQL error on content entity reward.
```
MyBB has experienced an internal SQL error and cannot continue.

SQL Error:
0 - ERROR: column "termination_point_id" does not exist LINE 9: termination_point_id = 1 ^
Query:
SELECT t1.* FROM mybb_mint_content_entity_rewards t1 WHERE user_id = 59 AND content_type = 'post' AND content_entity_id = 437 AND termination_point_id = 1

```