### PR TITLE
Remove trailing comma preventing installation

### DIFF
--- a/inc/plugins/mint.php
+++ b/inc/plugins/mint.php
@@ -320,7 +320,7 @@ function mint_activate()
         $PL->templates(
             'mint.' . $moduleName,
             'Mint: ' . $moduleName,
-            \mint\getFilesContentInDirectory(MYBB_ROOT . 'inc/plugins/mint/modules/' . $moduleName . '/templates', '.tpl'),
+            \mint\getFilesContentInDirectory(MYBB_ROOT . 'inc/plugins/mint/modules/' . $moduleName . '/templates', '.tpl')
         );
     }
 


### PR DESCRIPTION
Removes a trailing comma which was preventing installation. Interestingly this didn't trigger on my Docker test board using PHP 7.3, only on a live test board running 7.2.
```
syntax error, unexpected ')' in /var/www/mybb/inc/plugins/mint.php on line 324"
```