### PR TITLE
Remove non-existent column from user merge

### DIFF
--- a/inc/plugins/mint/hooks_acp.php
+++ b/inc/plugins/mint/hooks_acp.php
@@ -673,12 +673,6 @@ function admin_user_users_merge_commit(): void
                 'bid_user_id',
             ],
         ],
-        [
-            'class' => Items::class,
-            'columns' => [
-                'user_id',
-            ],
-        ],
     ];
 
     foreach ($dbRepositories as $repository) {


### PR DESCRIPTION
This was causing an SQL error when merging users because the column doesn't exist on the table so the escaped value ended up being empty when written into the query giving `...SET user_id = WHERE...`